### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://paulohenriquesi.visualstudio.com/f3e54d17-52c1-4472-9bc2-5d4961fa90de/bd3ea134-54d7-4f3f-acff-a71c3bf4b01d/_apis/work/boardbadge/4e88b7e2-5490-4787-a076-4833161d70be)](https://paulohenriquesi.visualstudio.com/f3e54d17-52c1-4472-9bc2-5d4961fa90de/_boards/board/t/bd3ea134-54d7-4f3f-acff-a71c3bf4b01d/Microsoft.RequirementCategory)
 # unittesting
 Projeto utilizado durante o curso de testes unitários.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#9](https://paulohenriquesi.visualstudio.com/f3e54d17-52c1-4472-9bc2-5d4961fa90de/_workitems/edit/9). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.